### PR TITLE
Move `/pause_reminder` and `/resume_reminder` commands to abandoned code storage

### DIFF
--- a/abandoned-code/README.md
+++ b/abandoned-code/README.md
@@ -1,0 +1,16 @@
+# 🗑️ Abandoned Code Storage
+This folder is solely for storing unusuable, retired or temporarily-removed code either for later use or **permanent removal and archival**.
+
+## What can I do with this code?
+You can simply inspect the code, you can try debugging it and fixing it, and if you feel like it's worthy of being in the bot, you can add it back and submit it for approval as a [pull request](https://github.com/PyBotDevs/water-reminder-bot/pulls).
+
+## What are the criteria for code to be abandoned?
+We obviously can't list all the possible criteria for code to get abandoned and end up here, but here are a few:
+
+* The code is unsupported by the client
+* The code is due of a rewrite
+* The code is unfixable (due to bugs)
+* The code is retired (removed from the bot)
+* The code is written, but is not ready for use in the bot yet
+
+<h6>NKA 2022 | Py | Discord | discord_slash | Discord library documentation</h6>

--- a/abandoned-code/README.md
+++ b/abandoned-code/README.md
@@ -13,4 +13,17 @@ We obviously can't list all the possible criteria for code to get abandoned and 
 * The code is retired (removed from the bot)
 * The code is written, but is not ready for use in the bot yet
 
+## Naming format
+If you feel like a snippet of code has to be abandoned from the bot, paste the code in a file in this folder. It should have this specific naming format:
+
+`{command names or descriptions}.{code language}.bak`
+
+For example, if I have to move a command named `test()` written in Python to this folder, it will be named:
+
+`test-command.py.bak`
+
+* "test-command" is the command name.
+* "py" is the language in which the code is written.
+* "bak" is the (general) backup file format.
+
 <h6>NKA 2022 | Py | Discord | discord_slash | Discord library documentation</h6>

--- a/abandoned-code/reminder-pause-resume.py.bak
+++ b/abandoned-code/reminder-pause-resume.py.bak
@@ -1,0 +1,26 @@
+@slash.slash(
+    name="pause_subscription",
+    description="Temporarily pauses your automatic water reminders"
+)
+async def pause_subscription(ctx: SlashContext):
+    print(f"[main/command client] /pause_subscription command invoked by user")
+    if str(ctx.author.id) not in users: return await ctx.reply("Oops! Looks like you aren't subscribed to water reminders yet! (you can subscribe using `/subscribe` command)", hidden=True)
+    if users[str(ctx.author.id)]["water_reminder"]["active"] is False: return await ctx.reply("Your water reminders are already paused.", hidden=True)
+    users[str(ctx.author.id)]["water_reminder"]["active"] = False
+    save()
+    localembed = discord.Embed(title=":pause_button: Your water reminders have been paused!", description="Whenever you want to, you can resume your water reminders with `/resume_subscription`.", color=discord.Color.light_grey())
+    await ctx.send(embed=localembed)
+
+
+@slash.slash(
+    name="resume_subscription",
+    description="Resumes your automatic water reminders"
+)
+async def resume_subscription(ctx: SlashContext):
+    print(f"[main/command client] /resume_subscription command invoked by user")
+    if str(ctx.author.id) not in users: return await ctx.reply("Oops! Looks like you aren't subscribed to water reminders yet! (you can subscribe using `/subscribe` command)", hidden=True)
+    if users[str(ctx.author.id)]["water_reminder"]["active"] is True: return await ctx.reply("Your water reminders are already active.", hidden=True)
+    users[str(ctx.author.id)]["water_reminder"]["active"] = True
+    save()
+    localembed = discord.Embed(title=":arrow_forward: Your water reminders have been resumed!", description="You will now start receiving automatic water reminders again!", color=discord.Color.green())
+    await ctx.send(embed=localembed)

--- a/main.py
+++ b/main.py
@@ -129,34 +129,6 @@ async def unsubscribe(ctx: SlashContext):
     await ctx.reply(embed=localembed)
 
 
-# @slash.slash(
-#     name="pause_subscription",
-#     description="Temporarily pauses your automatic water reminders"
-# )
-# async def pause_subscription(ctx: SlashContext):
-#     print(f"[main/command client] /pause_subscription command invoked by user")
-#     if str(ctx.author.id) not in users: return await ctx.reply("Oops! Looks like you aren't subscribed to water reminders yet! (you can subscribe using `/subscribe` command)", hidden=True)
-#     if users[str(ctx.author.id)]["water_reminder"]["active"] is False: return await ctx.reply("Your water reminders are already paused.", hidden=True)
-#     users[str(ctx.author.id)]["water_reminder"]["active"] = False
-#     save()
-#     localembed = discord.Embed(title=":pause_button: Your water reminders have been paused!", description="Whenever you want to, you can resume your water reminders with `/resume_subscription`.", color=discord.Color.light_grey())
-#     await ctx.send(embed=localembed)
-
-
-# @slash.slash(
-#     name="resume_subscription",
-#     description="Resumes your automatic water reminders"
-# )
-# async def resume_subscription(ctx: SlashContext):
-#     print(f"[main/command client] /resume_subscription command invoked by user")
-#     if str(ctx.author.id) not in users: return await ctx.reply("Oops! Looks like you aren't subscribed to water reminders yet! (you can subscribe using `/subscribe` command)", hidden=True)
-#     if users[str(ctx.author.id)]["water_reminder"]["active"] is True: return await ctx.reply("Your water reminders are already active.", hidden=True)
-#     users[str(ctx.author.id)]["water_reminder"]["active"] = True
-#     save()
-#     localembed = discord.Embed(title=":arrow_forward: Your water reminders have been resumed!", description="You will now start receiving automatic water reminders again!", color=discord.Color.green())
-#     await ctx.send(embed=localembed)
-
-
 @slash.slash(
     name="status",
     description="Shows the current bot status, along with a few other details"


### PR DESCRIPTION
I moved them to abandoned code storage, as the current reminder daemon implementation does not support pausing and resuming of reminders while running.

I might add them back once I add support for reminder pausing and resuming in reminder daemon.