### PR TITLE
Rewrite discord.py API wrapper with Pycord API wrapper

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,22 +1,18 @@
 ### NKA (aka. PyBotDevs) 2022. For enquiries contact <pybotdevs@outlook.com> ###
 
 # Imports
-from random import choices
-from click import option
 import discord
-from discord.ext import commands
-from discord.ext.commands import *
 # import os
 import os.path
 import time
-# from time import strftime
 import datetime
 import math
-from framework.isobot.colors import Colors
 import json
 import asyncio
+from framework.isobot.colors import Colors
 from threading import Thread
 from discord import ApplicationContext
+# from time import strftime
 
 # Configuration
 client = discord.Bot()

--- a/main.py
+++ b/main.py
@@ -3,8 +3,6 @@
 # Imports
 import discord
 from discord.ext import commands
-from discord_slash import SlashCommand, SlashContext
-from discord_slash.utils.manage_commands import create_option
 from discord.ext.commands import *
 # import os
 import os.path

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 ### NKA (aka. PyBotDevs) 2022. For enquiries contact <pybotdevs@outlook.com> ###
 
 # Imports
+from random import choices
+from click import option
 import discord
 from discord.ext import commands
 from discord.ext.commands import *
@@ -143,11 +145,9 @@ async def status(ctx: ApplicationContext):
 
 @client.slash_command(
     name="set_reminder_interval",
-    description="Sets a specified water reminder interval for you",
-    options=[
-        create_option(name="interval", description="How often do you want us to remind you to drink water?", option_type=str, required=True, choices=["30 minutes", "1 hour", "1.5 hours", "2 hours", "3 hours"])
-    ],
+    description="Sets a specified water reminder interval for you"
 )
+@option("interval", description="How often do you want us to remind you to drink water?", choices=["30 minutes", "1 hour", "1.5 hours", "2 hours", "3 hours"])
 async def set_reminder_interval(ctx: ApplicationContext, interval: str):
     print("[main/command client] /set_reminder_interval command invoked by user")
     if str(ctx.author.id) not in users: return await ctx.reply("Oops! Looks like you aren't subscribed to water reminders yet! (you can subscribe using `/subscribe` command)", hidden=True)

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ from framework.isobot.colors import Colors
 import json
 import asyncio
 from threading import Thread
+from discord import ApplicationContext
 
 # Configuration
 client = commands.Bot()
@@ -83,7 +84,7 @@ async def on_ready():
     name="subscribe",
     description="Sets up automatic water reminders for you"
 )
-async def subscribe(ctx: SlashContext):
+async def subscribe(ctx: ApplicationContext):
     print("[main/command client] /subscribe command invoked by user")
     if str(ctx.author.id) in users: return await ctx.reply("You are already subscribed to water reminders!", hidden=True)
     users[str(ctx.author.id)] = {
@@ -103,7 +104,7 @@ async def subscribe(ctx: SlashContext):
     name="subscription_list",
     description="Shows what reminders you are currently subscribed to"
 )
-async def subscription_list(ctx: SlashContext):
+async def subscription_list(ctx: ApplicationContext):
     print("[main/command client] /subscription_list command invoked by user")
     localembed = discord.Embed(title="Your subscription list", color=theme_color)
     if str(ctx.author.id) in users:
@@ -117,7 +118,7 @@ async def subscription_list(ctx: SlashContext):
     name="unsubscribe",
     description="Stops sending automatic water reminders to you"
 )
-async def unsubscribe(ctx: SlashContext):
+async def unsubscribe(ctx: ApplicationContext):
     print("[main/command client] /unsubscribe command invoked by user")
     if str(ctx.author.id) not in users: return await ctx.reply("Oops! Looks like you aren't subscribed to water reminders yet! (you can subscribe using `/subscribe` command)", hidden=True)
     del users[str(ctx.author.id)]
@@ -131,7 +132,7 @@ async def unsubscribe(ctx: SlashContext):
     name="status",
     description="Shows the current bot status, along with a few other details"
 )
-async def status(ctx: SlashContext):
+async def status(ctx: ApplicationContext):
     print("[main/command client] /status command invoked by user")
     localembed = discord.Embed(title="Bot status", color=theme_color)
     localembed.add_field(name="Current Latency (ping)", value=f"{round(client.latency, 2)} ms")
@@ -147,7 +148,7 @@ async def status(ctx: SlashContext):
         create_option(name="interval", description="How often do you want us to remind you to drink water?", option_type=str, required=True, choices=["30 minutes", "1 hour", "1.5 hours", "2 hours", "3 hours"])
     ],
 )
-async def set_reminder_interval(ctx: SlashContext, interval: str):
+async def set_reminder_interval(ctx: ApplicationContext, interval: str):
     print("[main/command client] /set_reminder_interval command invoked by user")
     if str(ctx.author.id) not in users: return await ctx.reply("Oops! Looks like you aren't subscribed to water reminders yet! (you can subscribe using `/subscribe` command)", hidden=True)
     secs = int()

--- a/main.py
+++ b/main.py
@@ -18,8 +18,8 @@ import asyncio
 from threading import Thread
 
 # Configuration
-client = commands.Bot(command_prefix='w!', intents=discord.Intents.all())
-slash = SlashCommand(client, sync_commands=True)
+client = commands.Bot()
+# slash = SlashCommand(client, sync_commands=True)
 start_time = math.floor(time.time())
 start_timestamp = datetime.datetime.now()
 colors = Colors()
@@ -81,7 +81,7 @@ async def on_ready():
 
 
 # Commands
-@slash.slash(
+@client.slash_command(
     name="subscribe",
     description="Sets up automatic water reminders for you"
 )
@@ -101,7 +101,7 @@ async def subscribe(ctx: SlashContext):
     await reminder_daemon.start_reminder(ctx.author.id, 7200)
 
 
-@slash.slash(
+@client.slash_command(
     name="subscription_list",
     description="Shows what reminders you are currently subscribed to"
 )
@@ -115,7 +115,7 @@ async def subscription_list(ctx: SlashContext):
     await ctx.send(embed=localembed)
 
 
-@slash.slash(
+@client.slash_command(
     name="unsubscribe",
     description="Stops sending automatic water reminders to you"
 )
@@ -129,7 +129,7 @@ async def unsubscribe(ctx: SlashContext):
     await ctx.reply(embed=localembed)
 
 
-@slash.slash(
+@client.slash_command(
     name="status",
     description="Shows the current bot status, along with a few other details"
 )
@@ -142,7 +142,7 @@ async def status(ctx: SlashContext):
     await ctx.send(embed=localembed)
 
 
-@slash.slash(
+@client.slash_command(
     name="set_reminder_interval",
     description="Sets a specified water reminder interval for you",
     options=[

--- a/main.py
+++ b/main.py
@@ -17,7 +17,6 @@ from discord import ApplicationContext
 
 # Configuration
 client = discord.Bot()
-# slash = SlashCommand(client, sync_commands=True)
 start_time = math.floor(time.time())
 start_timestamp = datetime.datetime.now()
 colors = Colors()

--- a/main.py
+++ b/main.py
@@ -2,7 +2,6 @@
 
 # Imports
 import discord
-# import os
 import os.path
 import time
 import datetime
@@ -13,6 +12,7 @@ from framework.isobot.colors import Colors
 from threading import Thread
 from discord import option
 from discord import ApplicationContext
+# import os
 # from time import strftime
 
 # Configuration

--- a/main.py
+++ b/main.py
@@ -84,7 +84,7 @@ async def on_ready():
 )
 async def subscribe(ctx: ApplicationContext):
     print("[main/command client] /subscribe command invoked by user")
-    if str(ctx.author.id) in users: return await ctx.reply("You are already subscribed to water reminders!", hidden=True)
+    if str(ctx.author.id) in users: return await ctx.respond("You are already subscribed to water reminders!", hidden=True)
     users[str(ctx.author.id)] = {
         "water_reminder": {
             "active": True,
@@ -94,7 +94,7 @@ async def subscribe(ctx: ApplicationContext):
     }
     save()
     localembed = discord.Embed(title=":potable_water: Your water reminder is set!", description="We will now remind you every 2 hours to drink water.\nIf you ever want to cancel these reminders, you can type `/unsubscribe`.", color=theme_color)
-    await ctx.reply(embed=localembed)
+    await ctx.respond(embed=localembed)
     await reminder_daemon.start_reminder(ctx.author.id, 7200)
 
 
@@ -118,12 +118,12 @@ async def subscription_list(ctx: ApplicationContext):
 )
 async def unsubscribe(ctx: ApplicationContext):
     print("[main/command client] /unsubscribe command invoked by user")
-    if str(ctx.author.id) not in users: return await ctx.reply("Oops! Looks like you aren't subscribed to water reminders yet! (you can subscribe using `/subscribe` command)", hidden=True)
+    if str(ctx.author.id) not in users: return await ctx.respond("Oops! Looks like you aren't subscribed to water reminders yet! (you can subscribe using `/subscribe` command)", hidden=True)
     del users[str(ctx.author.id)]
     save()
     await reminder_daemon.stop_reminder(ctx.author.id)
     localembed = discord.Embed(title=":broken_heart: You have successfully unsubscribed from water reminders!", description="You will not be sent frequent reminders to drink water anymore.\nHowever, you can always subscribe back by using the `/subscribe` command!")
-    await ctx.reply(embed=localembed)
+    await ctx.respond(embed=localembed)
 
 
 @client.slash_command(
@@ -146,7 +146,7 @@ async def status(ctx: ApplicationContext):
 @option("interval", description="How often do you want us to remind you to drink water?", choices=["30 minutes", "1 hour", "1.5 hours", "2 hours", "3 hours"])
 async def set_reminder_interval(ctx: ApplicationContext, interval: str):
     print("[main/command client] /set_reminder_interval command invoked by user")
-    if str(ctx.author.id) not in users: return await ctx.reply("Oops! Looks like you aren't subscribed to water reminders yet! (you can subscribe using `/subscribe` command)", hidden=True)
+    if str(ctx.author.id) not in users: return await ctx.respond("Oops! Looks like you aren't subscribed to water reminders yet! (you can subscribe using `/subscribe` command)", hidden=True)
     secs = int()
     if interval == "30 minutes": secs = 60*30
     elif interval == "1 hour": secs = 60*60

--- a/main.py
+++ b/main.py
@@ -109,12 +109,12 @@ async def subscription_list(ctx: ApplicationContext):
         if users[str(ctx.author.id)]["water_reminder"]["active"] is True: localembed.add_field(name="Water Reminders", value="Currently Subscribed")
         elif users[str(ctx.author.id)]["water_reminder"]["active"] is False: localembed.add_field(name="Water Reminders", value="Subscription Paused")
     else: localembed.add_field(name="Water Reminders", value="Not Subscribed")
-    await ctx.send(embed=localembed)
+    await ctx.respond(embed=localembed)
 
 
 @client.slash_command(
     name="unsubscribe",
-    description="Stops sending automatic water reminders to you"
+    description="Stops responding automatic water reminders to you"
 )
 async def unsubscribe(ctx: ApplicationContext):
     print("[main/command client] /unsubscribe command invoked by user")
@@ -136,7 +136,7 @@ async def status(ctx: ApplicationContext):
     localembed.add_field(name="Current Latency (ping)", value=f"{round(client.latency, 2)} ms")
     localembed.add_field(name="Client Startup Time", value=f"{math.floor(time.time()) - start_time} seconds")
     localembed.add_field(name="Time Started", value=start_timestamp.strftime("%H:%M:%S on %d/%m/%Y"))
-    await ctx.send(embed=localembed)
+    await ctx.respond(embed=localembed)
 
 
 @client.slash_command(
@@ -158,7 +158,7 @@ async def set_reminder_interval(ctx: ApplicationContext, interval: str):
     await reminder_daemon.stop_reminder(ctx.author.id)
     time.sleep(0.1)
     localembed = discord.Embed(title=":white_check_mark: Interval set!", description=f"We will now remind you every {interval} to drink water!", color=theme_color)
-    await ctx.send(embed=localembed)
+    await ctx.respond(embed=localembed)
     await reminder_daemon.start_reminder(ctx.author.id, int(users[str(ctx.author.id)]["water_reminder"]["interval"]))
 
 

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ from threading import Thread
 from discord import ApplicationContext
 
 # Configuration
-client = commands.Bot()
+client = discord.Bot()
 # slash = SlashCommand(client, sync_commands=True)
 start_time = math.floor(time.time())
 start_timestamp = datetime.datetime.now()

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ import json
 import asyncio
 from framework.isobot.colors import Colors
 from threading import Thread
+from discord import option
 from discord import ApplicationContext
 # from time import strftime
 


### PR DESCRIPTION
### Pycord - Water Reminder Bot Rewrite
Since discord.py is now not supported anymore, and with the lack of support that `discord.py` combined with `discord-py-slash-command` provides for Discord bots, I decided to rewrite Water Reminder Bot with the Pycord Discord API wrapper. This provides a faster client with less bloat, greater capability, more features, and better support. This also reduces the space taken up by the bot in the host, as only one library is required, not two.

Pycord Documentation - https://docs.pycord.dev/en/stable/index.html