### PR TITLE
Fix reminder daemon not being able to send DM reminders due to `send()` attribute error

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ class ReminderDaemon:
         self.reminders.append(str(user_id))
         while str(user_id) in self.reminders:
             await asyncio.sleep(interval)
-            user_data = client.get_user(user_id)
+            user_data: discord.User = await client.fetch_user(str(user_id))
             localembed = discord.Embed(title="It's time to drink water!", description="Grab a glass or water bottle, and hydrate yourself!", color=theme_color)
             await user_data.send(embed=localembed)
 


### PR DESCRIPTION
### Switched from using `client.get_user()` to using `client.fetch_user()`. 

`get_user()` uses local user cache, but `fetch_user()` retrieves new data from the API which reduces reminder daemon's error rate while sending DM reminders.